### PR TITLE
Add exchange method to DHPrivateKey abstract base class.

### DIFF
--- a/src/cryptography/hazmat/primitives/asymmetric/dh.py
+++ b/src/cryptography/hazmat/primitives/asymmetric/dh.py
@@ -154,6 +154,13 @@ class DHPrivateKeyWithSerialization(DHPrivateKey):
         Returns a DHPrivateNumbers.
         """
 
+    @abc.abstractmethod
+    def exchange(self, peer_public_key):
+        """
+        Given peer's DHPublicKey, carry out the key exchange and
+        return shared key as bytes.
+        """
+
 
 @six.add_metaclass(abc.ABCMeta)
 class DHPublicKey(object):


### PR DESCRIPTION
Was this method supposed to be part of the abc?
